### PR TITLE
Enable cloning from URLs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,15 +23,6 @@ jobs:
         with:
           dotnet-version: 7.0.x
 
-      - name: get version
-        id: version
-        uses: notiz-dev/github-action-json-property@release
-        with:
-          path: "Flow.Launcher.Plugin.GitEasy/plugin.json"
-          prop_path: "Version"
-
-      - run: echo ${{steps.version.outputs.prop}}
-
       - name: Restore dependencies
         run: |
           cd Flow.Launcher.Plugin.GitEasy
@@ -41,4 +32,9 @@ jobs:
         run: |
           cd Flow.Launcher.Plugin.GitEasy
           dotnet publish -c Release -r win-x64 --no-self-contained Flow.Launcher.Plugin.GitEasy.csproj
-          7z a -tzip "Flow.Launcher.Plugin.GitEasy.zip" "./bin/Release/Plugins/Flow.Launcher.Plugin.GitEasy/win-x64/publish/*"
+      
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Flow.Launcher.Plugin.GitEasy
+          path: ./Flow.Launcher.Plugin.GitEasy/bin/Release/Plugins/Flow.Launcher.Plugin.GitEasy/win-x64/publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,10 +4,8 @@ permissions:
   contents: write
 
 on:
-  workflow_dispatch:
   push:
-    branches-ignore:
-      - "main"
+    branches: ["main"]
     paths-ignore:
       - "**/README.md"
 
@@ -42,3 +40,11 @@ jobs:
           cd Flow.Launcher.Plugin.GitEasy
           dotnet publish -c Release -r win-x64 --no-self-contained Flow.Launcher.Plugin.GitEasy.csproj
           7z a -tzip "Flow.Launcher.Plugin.GitEasy.zip" "./bin/Release/Plugins/Flow.Launcher.Plugin.GitEasy/win-x64/publish/*"
+
+      - name: Publish
+        uses: softprops/action-gh-release@v1
+        with:
+          files: "Flow.Launcher.Plugin.GitEasy/Flow.Launcher.Plugin.GitEasy.zip"
+          tag_name: "v${{steps.version.outputs.prop}}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Flow.Launcher.Plugin.GitEasy/Models/Commands/CloneCommand.cs
+++ b/Flow.Launcher.Plugin.GitEasy/Models/Commands/CloneCommand.cs
@@ -172,9 +172,11 @@ public class CloneCommand : ICommand
 
     private string ExtractRepoName(string url)
     {
+        if (url.EndsWith(".git", StringComparison.OrdinalIgnoreCase))
+            url = url.Substring(0, url.Length - 4);
+
         // Look for the last index of the last slash /
-        int start = url.LastIndexOf('/') + 1;
-        return url.Substring(start, url.Length - start - 4);
+        return url.Substring(url.LastIndexOf('/') + 1);
     }
     #endregion
 }

--- a/Flow.Launcher.Plugin.GitEasy/Services/GitCommandService.cs
+++ b/Flow.Launcher.Plugin.GitEasy/Services/GitCommandService.cs
@@ -1,4 +1,4 @@
-﻿using Flow.Launcher.Plugin.GitEasy.Models.Commands.EventArgs;
+using Flow.Launcher.Plugin.GitEasy.Models.Commands.EventArgs;
 using Flow.Launcher.Plugin.GitEasy.Models.Commands.Options;
 using Flow.Launcher.Plugin.GitEasy.Services.Interfaces;
 using System;
@@ -63,7 +63,8 @@ public class GitCommandService : IGitCommandService
         ProcessStartInfo info = new()
         {
             FileName = "git.exe",
-            WorkingDirectory = options.DestinationFolder
+            WorkingDirectory = options.DestinationFolder,
+            CreateNoWindow = true
         };
 
         info.ArgumentList.Add("clone");
@@ -84,6 +85,7 @@ public class GitCommandService : IGitCommandService
         {
             FileName = "git.exe",
             WorkingDirectory = options.RepoPath,
+            CreateNoWindow = true
         };
 
         info.ArgumentList.Add("fetch");

--- a/Flow.Launcher.Plugin.GitEasy/Utilities/RegexUtils.cs
+++ b/Flow.Launcher.Plugin.GitEasy/Utilities/RegexUtils.cs
@@ -4,6 +4,6 @@ namespace Flow.Launcher.Plugin.GitEasy.Utilities;
 
 public static partial class RegexUtils
 {
-    [GeneratedRegex("(git@|https:\\/\\/).*.git")]
+    [GeneratedRegex(@"^(git@|https://).*(?:\.git)?$")]
     public static partial Regex ReposRegex();
 }

--- a/Flow.Launcher.Plugin.GitEasy/plugin.json
+++ b/Flow.Launcher.Plugin.GitEasy/plugin.json
@@ -4,7 +4,7 @@
   "Name": "Git Easy",
   "Description": "Provide easy access to repositories. Allows quickly cloning repository and open in vscode/file explorer.",
   "Author": "zkwokleung",
-  "Version": "0.5.0",
+  "Version": "0.5.1",
   "Language": "csharp",
   "Website": "https://github.com/zkwokleung/Flow.Launcher.Plugin.GitEasy",
   "IcoPath": "Images/icon.png",

--- a/Readme.md
+++ b/Readme.md
@@ -25,7 +25,7 @@ This started as a very personal project. You are very welcomed to contribute and
 | Command                    | Description                                | Example                                                                   |
 |----------------------------|--------------------------------------------|---------------------------------------------------------------------------|
 | `` ge ``                   | Show all commands                          |                                                                           |
-| `` ge clone <url> ``       | Clone a repository. A separate result appears for each configured root folder so you can choose where to clone. | `` ge clone git@github.com:zkwokleung/Flow.Launcher.Plugin.GitEasy.git `` |
+| `` ge clone <url> ``       | Clone a repository. A separate result appears for each configured root folder so you can choose where to clone. | `` ge clone git@github.com:zkwokleung/Flow.Launcher.Plugin.GitEasy.git ``<br>`` ge clone https://github.com/zkwokleung/Flow.Launcher.Plugin.GitEasy `` |
 | `` ge open <repo name> ``  | Open a repository in File Explorer/VS Code | `` ge open Flow.Launcher.Plugin.GitEasy ``                                |
 | `` ge fetch <repo name> `` | Fetch a repository                         | `` ge fetch Flow.Launcher.Plugin.GitEasy ``                               |
 


### PR DESCRIPTION
**Changes:**
- Make `.git` suffix optional so can clone from `https://github.com/zkwokleung/Flow.Launcher.Plugin.GitEasy`
- Add new build workflow so the uploaded artifact can be used to test (old build.yml renamed to release.yml)
- Fix the terminal window popup when running the git commands

**Tested**:
- Can clone from `git@github.com:zkwokleung/Flow.Launcher.Plugin.GitEasy.git`
- Can clone from `https://github.com/zkwokleung/Flow.Launcher.Plugin.GitEasy`